### PR TITLE
Fix LoadProhibited when using SoftwareSerial in a funky way.

### DIFF
--- a/lib/ZE25-O3/ZE25.cpp
+++ b/lib/ZE25-O3/ZE25.cpp
@@ -41,11 +41,11 @@ uint8_t ZE25::calculateChecksum(uint8_t msg[kMessageLength]){
     return checksum;
 }
 
-ZE25::ZE25(HardwareSerial& device) : hw_stream_ (&device) {
+ZE25::ZE25(HardwareSerial& device) : hw_stream_ (&device), sw_stream_(nullptr) {
     setStream();
 }
 
-ZE25::ZE25(SoftwareSerial& device) : sw_stream_(&device) {
+ZE25::ZE25(SoftwareSerial& device) : sw_stream_(&device), hw_stream_(nullptr) {
     setStream();
 }
 

--- a/lib/ZE27-O3/ZE27.cpp
+++ b/lib/ZE27-O3/ZE27.cpp
@@ -41,11 +41,11 @@ uint8_t ZE27::calculateChecksum(uint8_t msg[kMessageLength]){
     return checksum;
 }
 
-ZE27::ZE27(HardwareSerial& device) : hw_stream_ (&device) {
+ZE27::ZE27(HardwareSerial& device) : hw_stream_ (&device), sw_stream_(nullptr) {
     setStream();
 }
 
-ZE27::ZE27(SoftwareSerial& device) : sw_stream_(&device) {
+ZE27::ZE27(SoftwareSerial& device) : sw_stream_(&device), hw_stream_(nullptr) {
     setStream();
 }
 


### PR DESCRIPTION
Hey, I ran into a slight initialization issue when when running ZE27-O3 in my project:

```
Guru Meditation Error: Core  1 panic'ed (LoadProhibited). Exception was unhandled.
```

I narrowed it down to the `setStream()` call entering the wrong case (as if HW serial was used when in actuality it was SW serial) and performing an invalid load (most likely a null-ish pointer dereference). It was a pretty easy fix - just initializing the HW and SW internal variables to nullptr so that we make sure only the right one is non-null. Tested it with both ZE25 and ZE27 libs (looks like it's the same code really :shrug:).
Haven't changed the other sensors setup.